### PR TITLE
Bumped dependency linked-list-allocator, fixed feature warn.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Bumped the dependency of the `linked_list_allocator` crate to v0.8.1.
+- Removed `#![feature(alloc)]` to supress compiler warning about stability for alloc 
+
 ## [v0.3.5] - 2018-06-19
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ cortex-m = "0.1.5"
 
 [dependencies.linked_list_allocator]
 default-features = false
-version = "0.6.0"
+version = "0.8.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@
 //! // omitted: exception handlers
 //! ```
 
-#![feature(alloc)]
 #![feature(allocator_api)]
 #![feature(const_fn)]
 #![no_std]


### PR DESCRIPTION
Fix regarding [this issue](https://github.com/rust-embedded/alloc-cortex-m/issues/28#issue-581374231).