### PR TITLE
Update the crate to compile with newest nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "alloc-cortex-m"
 version = "0.3.5"
 
 [dependencies]
-cortex-m = "0.1.5"
+cortex-m = "0.6.2"
 
 [dependencies.linked_list_allocator]
 default-features = false


### PR DESCRIPTION
The latest nightly removed the `asm!` syntax, which broke the ancient `cortex-m` this crate depends on. This PR updates the dependency and works around the fact that `Mutex::lock` was somewhere lost in history.