### PR TITLE
Update to Cortex-M dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Bumped the dependency of the `linked_list_allocator` crate to v0.8.1.
+- Bumped the dependency of the `cortex-m` crate to v0.6.2.
+- Bumped the dependency of the `linked_list_allocator` crate to v0.8.4.
 - Removed `#![feature(alloc)]` to supress compiler warning about stability for alloc 
 
 ## [v0.3.5] - 2018-06-19

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ name = "alloc-cortex-m"
 version = "0.3.5"
 
 [dependencies]
-cortex-m = "0.1.5"
+cortex-m = "0.6.2"
 
 [dependencies.linked_list_allocator]
 default-features = false
-version = "0.8.1"
+version = "0.8.4"
 
 [dev-dependencies]
 cortex-m-rt = "0.6.12"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,13 @@
 #![no_std]
 
 use core::alloc::{GlobalAlloc, Layout};
-use core::ptr::NonNull;
+use core::{cell::RefCell, ptr::NonNull};
 
 use cortex_m::interrupt::Mutex;
 use linked_list_allocator::Heap;
 
 pub struct CortexMHeap {
-    heap: Mutex<Heap>,
+    heap: Mutex<RefCell<Heap>>,
 }
 
 impl CortexMHeap {
@@ -25,7 +25,7 @@ impl CortexMHeap {
     /// [`init`](struct.CortexMHeap.html#method.init) method before using the allocator.
     pub const fn empty() -> CortexMHeap {
         CortexMHeap {
-            heap: Mutex::new(Heap::empty()),
+            heap: Mutex::new(RefCell::new(Heap::empty())),
         }
     }
 
@@ -53,20 +53,30 @@ impl CortexMHeap {
     /// - This function must be called exactly ONCE.
     /// - `size > 0`
     pub unsafe fn init(&self, start_addr: usize, size: usize) {
-        self.heap.lock(|heap| heap.init(start_addr, size));
+        cortex_m::interrupt::free(|cs| {
+            self.heap.borrow(cs).borrow_mut().init(start_addr, size);
+        });
     }
 }
 
 unsafe impl GlobalAlloc for CortexMHeap {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        self.heap
-            .lock(|heap| heap.allocate_first_fit(layout))
-            .ok()
-            .map_or(0 as *mut u8, |allocation| allocation.as_ptr())
+        cortex_m::interrupt::free(|cs| {
+            self.heap
+                .borrow(cs)
+                .borrow_mut()
+                .allocate_first_fit(layout)
+                .ok()
+                .map_or(0 as *mut u8, |allocation| allocation.as_ptr())
+        })
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        self.heap
-            .lock(|heap| heap.deallocate(NonNull::new_unchecked(ptr), layout));
+        cortex_m::interrupt::free(|cs| {
+            self.heap
+                .borrow(cs)
+                .borrow_mut()
+                .deallocate(NonNull::new_unchecked(ptr), layout);
+        });
     }
 }


### PR DESCRIPTION
The old cortex-m crates are now no longer supported due to the asm! syntax changes.
The current release still hasn't got support for it, but it's already on the master.

With this update, it's possible to use the master version of cortex-m with a patch.