### PR TITLE
Exposed `used` and `free` methods on CortexMHeap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,26 @@ impl CortexMHeap {
                 .init(start_addr, size);
         });
     }
+
+    /// Returns an estimate of the amount of bytes in use.
+    pub fn used(&self) -> usize {
+        cortex_m::interrupt::free(|cs| {
+            self.heap
+                .borrow(cs)
+                .borrow_mut()
+                .used()
+        })
+    }
+
+    /// Returns an estimate of the amount of bytes available.
+    pub fn free(&self) -> usize {
+        cortex_m::interrupt::free(|cs| {
+            self.heap
+                .borrow(cs)
+                .borrow_mut()
+                .free()
+        })
+    }
 }
 
 unsafe impl GlobalAlloc for CortexMHeap {


### PR DESCRIPTION
Added two methods that expose existing functions on the Heap:
- https://docs.rs/linked_list_allocator/0.8.4/linked_list_allocator/struct.Heap.html#method.used
- https://docs.rs/linked_list_allocator/0.8.4/linked_list_allocator/struct.Heap.html#method.free

The functions should be generic enough that it doesn't pin alloc-cortex-m to a specific implementation. This is the reason the documentation mentions that the methods return an "estimate", as future implementations might not be accurate.