### PR TITLE
fix: remove usage of HEAP mut ref in example

### DIFF
--- a/examples/global_alloc.rs
+++ b/examples/global_alloc.rs
@@ -20,7 +20,7 @@ fn main() -> ! {
         use core::mem::MaybeUninit;
         const HEAP_SIZE: usize = 1024;
         static mut HEAP: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
-        unsafe { ALLOCATOR.init((&mut HEAP).as_ptr() as usize, HEAP_SIZE) }
+        unsafe { ALLOCATOR.init(HEAP.as_ptr() as usize, HEAP_SIZE) }
     }
 
     let mut xs = Vec::new();


### PR DESCRIPTION
Remove &mut and just use .as_ptr() as the function requires