### PR TITLE
Add nrf softdevice feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ nrf-softdevice = ["dep:critical-section", "dep:embassy"]
 
 [dev-dependencies]
 cortex-m-rt = "0.6.12"
+
+# [patch.crates-io]
+# embassy = { git = "https://github.com/embassy-rs/embassy" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,16 @@ default-features = false
 version = "0.8.11"
 features = ["const_mut_refs"]
 
+[dependencies.critical-section]
+version = "0.2.7"
+optional = true
+
+[dependencies.embassy]
+version = "0.1.0"
+optional = true
+
+[features]
+nrf-softdevice = ["dep:critical-section", "dep:embassy"]
+
 [dev-dependencies]
 cortex-m-rt = "0.6.12"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ This project is developed and maintained by the [Cortex-M team][team].
 
 ## [Documentation](https://docs.rs/alloc-cortex-m)
 
+## Features
+
+The `nrf-softdevice` feature replaces `cortex_m::interrupt::free()` with
+`critical_section::with()` when block interrupts.
+
 ## [Change log](CHANGELOG.md)
 
 ## License


### PR DESCRIPTION
As has attempted to be described in the commit message, this is intended to address using this crate with Nordic Semiconductor's SoCs by adding a feature for acting slightly different with them. Since it adds a dependency on embassy, which is not yet distributed through crates.io, this is a draft pull request until the required crates have been stabilized.

There are likely improvements to be made to the details, but the main question should likely be; Could this addition stand a chance to get merged once the eco-system matures, or would doing this in some other way be considered a more
appropriate solution?