### PR TITLE
update `linked_list_allocator` to `0.10.4`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cortex-m = "0.7.2"
 
 [dependencies.linked_list_allocator]
 default-features = false
-version = "0.8.11"
+version = "0.10.4"
 features = ["const_mut_refs"]
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,10 @@ impl CortexMHeap {
     /// - `size > 0`
     pub unsafe fn init(&self, start_addr: usize, size: usize) {
         cortex_m::interrupt::free(|cs| {
-            self.heap.borrow(cs).borrow_mut().init(start_addr, size);
+            self.heap
+                .borrow(cs)
+                .borrow_mut()
+                .init(start_addr as *mut u8, size);
         });
     }
 


### PR DESCRIPTION
versions <= 0.10.1 were affected by [CVE-2022-36086][].
note that with 0.10.0 a breaking API change was done which changed the signature of `init`. this can however be avoided simply by casting back (to avoid a breaking API change in `alloc-cortex-m` by changing the API here as well - if wished, this should be done as a separate step).

i've also tried to instead switch to the `init_from_slice` API (introduced in 0.9.1), however I've failed at getting this to compile due to lifetimes (i'm sure it's somehow possible and i just missed the obvious...), but that'd anyway have been a breaking change for `alloc-cortex-m` and, if done, should be done in a separate step (though it'd definitely clean the API up and make it nicer!).

[CVE-2022-36086]: https://github.com/advisories/GHSA-xg8p-34w2-j49j